### PR TITLE
Add query modules and streamline env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ uploads/
 pnpm-lock.yaml
 public/
 .DS_Store
-src/queries

--- a/src/config/.env.example
+++ b/src/config/.env.example
@@ -18,17 +18,29 @@ FRONTEND_URL=http://localhost:3000
 
 # File Upload
 MAX_FILE_SIZE=10485760 # 10MB
-UPLOAD_DIR=uploads
+ALLOWED_FILE_TYPES=image/jpeg,image/png,image/gif
+
+# Redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_USERNAME=
+REDIS_PASSWORD=
+
+# Twilio
+TWILIO_ACCOUNT_SID=your-account-sid
+TWILIO_AUTH_TOKEN=your-auth-token
+
+# Affiliate
+AFFILIATE_BASE_URL=https://example.com/aff
 
 # Email
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER=your-email@gmail.com
 SMTP_PASS=your-app-specific-password
+SMTP_FROM=your-email@gmail.com
+EMAIL_FROM_NAME=Your Name
+EMAIL_FROM_ADDRESS=your-email@gmail.com
 
-# Optional Services
-REDIS_URL=redis://localhost:6379
-AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=your-access-key
-AWS_SECRET_ACCESS_KEY=your-secret-key
-S3_BUCKET=your-bucket-name
+# TextMeBot
+TEXTMEBOT_API_KEY=gz6kj5DdgBky

--- a/src/queries/affiliate.queries.js
+++ b/src/queries/affiliate.queries.js
@@ -1,0 +1,38 @@
+module.exports = {
+  CREATE_PRODUCT: `
+    INSERT INTO affiliate_products (name, description, price, external_url, platform)
+    VALUES ($1, $2, $3, $4, $5)
+    RETURNING *
+  `,
+  CREATE_AFFILIATE_LINK: `
+    INSERT INTO affiliate_links (user_id, product_id, affiliate_url)
+    VALUES ($1, $2, $3)
+    RETURNING *
+  `,
+  RECORD_CLICK: `
+    INSERT INTO affiliate_clicks (link_id, user_id, ip_address, user_agent, referer)
+    VALUES ($1, $2, $3, $4, $5)
+    RETURNING *
+  `,
+  UPDATE_CLICK_COUNT: `
+    UPDATE affiliate_links
+    SET clicks_count = clicks_count + 1
+    WHERE id = $1
+  `,
+  RECORD_PURCHASE: `
+    INSERT INTO affiliate_purchases (click_id, order_id, amount, commission)
+    VALUES ($1, $2, $3, $4)
+    RETURNING *
+  `,
+  GET_USER_EARNINGS: `
+    SELECT total_earned, pending_amount
+    FROM user_earnings
+    WHERE user_id = $1
+  `,
+  GET_AFFILIATE_STATS: `
+    SELECT al.id, ap.name, al.clicks_count, al.conversions_count
+    FROM affiliate_links al
+    JOIN affiliate_products ap ON ap.id = al.product_id
+    WHERE al.user_id = $1
+  `
+};

--- a/src/queries/friends.queries.js
+++ b/src/queries/friends.queries.js
@@ -1,0 +1,52 @@
+module.exports = {
+  getFriends: `
+    SELECT f.id,
+           CASE WHEN f.user_id = $1 THEN f.friend_id ELSE f.user_id END AS friend_id,
+           f.status,
+           f.created_at
+    FROM friends f
+    WHERE (f.user_id = $1 OR f.friend_id = $1) AND f.status = 'accepted'
+  `,
+  getIncomingRequests: `
+    SELECT f.*
+    FROM friends f
+    WHERE f.friend_id = $1 AND f.status = 'pending'
+  `,
+  getOutgoingRequests: `
+    SELECT f.*
+    FROM friends f
+    WHERE f.user_id = $1 AND f.status = 'pending'
+  `,
+  getFriendshipStatus: `
+    SELECT * FROM friends
+    WHERE (user_id = $1 AND friend_id = $2) OR (user_id = $2 AND friend_id = $1)
+  `,
+  sendFriendRequest: `
+    INSERT INTO friends (user_id, friend_id)
+    VALUES ($1, $2)
+    RETURNING *
+  `,
+  acceptFriendRequest: `
+    UPDATE friends
+    SET status = 'accepted'
+    WHERE id = $1
+    RETURNING *
+  `,
+  rejectFriendRequest: `
+    UPDATE friends
+    SET status = 'rejected'
+    WHERE id = $1
+    RETURNING *
+  `,
+  blockFriend: `
+    UPDATE friends
+    SET status = 'blocked'
+    WHERE id = $1
+    RETURNING *
+  `,
+  removeFriend: `
+    DELETE FROM friends
+    WHERE id = $1
+    RETURNING *
+  `
+};

--- a/src/queries/interests.queries.js
+++ b/src/queries/interests.queries.js
@@ -1,0 +1,31 @@
+module.exports = {
+  LIST_INTERESTS: `
+    SELECT * FROM user_interests
+    ORDER BY name
+  `,
+  GET_USER_INTERESTS: `
+    SELECT ui.id, ui.name, ui.display_name, uim.affinity_score
+    FROM user_interest_map uim
+    JOIN user_interests ui ON ui.id = uim.interest_id
+    WHERE uim.user_id = $1
+  `,
+  GET_RECOMMENDED_CONTENT: `
+    SELECT p.*
+    FROM posts p
+    WHERE p.visibility = 'public'
+    ORDER BY p.created_at DESC
+    LIMIT $2 OFFSET $3
+  `,
+  GET_SUGGESTED_USERS: `
+    SELECT u.id, u.username, u.avatar_url
+    FROM users u
+    WHERE u.id != $1 AND u.deleted_at IS NULL
+    ORDER BY u.created_at DESC
+    LIMIT $2 OFFSET $3
+  `,
+  UPDATE_INTEREST_AFFINITY: `
+    UPDATE user_interest_map
+    SET affinity_score = $3
+    WHERE user_id = $1 AND interest_id = $2
+  `
+};

--- a/src/queries/messages.queries.js
+++ b/src/queries/messages.queries.js
@@ -1,0 +1,59 @@
+module.exports = {
+  CREATE_CONVERSATION: `
+    INSERT INTO conversations (creator_id, title, type)
+    VALUES ($1, $2, $3)
+    RETURNING *
+  `,
+  ADD_PARTICIPANT: `
+    INSERT INTO conversation_participants (conversation_id, user_id, role)
+    VALUES ($1, $2, $3)
+  `,
+  GET_CONVERSATIONS: `
+    SELECT c.*
+    FROM conversations c
+    JOIN conversation_participants cp ON cp.conversation_id = c.id
+    WHERE cp.user_id = $1 AND c.deleted_at IS NULL
+    ORDER BY c.updated_at DESC
+    LIMIT $2 OFFSET $3
+  `,
+  GET_MESSAGES: `
+    SELECT *
+    FROM messages
+    WHERE conversation_id = $1 AND deleted_at IS NULL
+    ORDER BY created_at ASC
+    LIMIT $2 OFFSET $3
+  `,
+  MARK_MESSAGES_READ: `
+    UPDATE conversation_participants
+    SET last_read_at = NOW()
+    WHERE conversation_id = $1 AND user_id = $2
+  `,
+  GET_UNREAD_COUNT: `
+    SELECT cp.conversation_id, COUNT(m.id) AS unread_count
+    FROM conversation_participants cp
+    JOIN messages m ON m.conversation_id = cp.conversation_id
+    WHERE cp.user_id = $1
+      AND m.created_at > COALESCE(cp.last_read_at, 'epoch')
+      AND m.deleted_at IS NULL
+    GROUP BY cp.conversation_id
+  `,
+  DELETE_MESSAGE: `
+    DELETE FROM messages
+    WHERE id = $1 AND sender_id = $2
+    RETURNING *
+  `,
+  CHECK_PARTICIPANT: `
+    SELECT 1 FROM conversation_participants
+    WHERE conversation_id = $1 AND user_id = $2
+  `,
+  CREATE_MESSAGE: `
+    INSERT INTO messages (conversation_id, sender_id, message, media_url)
+    VALUES ($1, $2, $3, $4)
+    RETURNING *
+  `,
+  GET_CONVERSATION_PARTICIPANTS: `
+    SELECT user_id
+    FROM conversation_participants
+    WHERE conversation_id = $1 AND user_id != $2
+  `
+};

--- a/src/queries/notifications.queries.js
+++ b/src/queries/notifications.queries.js
@@ -1,0 +1,33 @@
+module.exports = {
+  GET_NOTIFICATIONS: `
+    SELECT * FROM notifications
+    WHERE user_id = $1
+    ORDER BY created_at DESC
+    LIMIT $2 OFFSET $3
+  `,
+  GET_UNREAD_COUNT: `
+    SELECT COUNT(*) FROM notifications
+    WHERE user_id = $1 AND is_read = false
+  `,
+  MARK_AS_READ: `
+    UPDATE notifications
+    SET is_read = true, read_at = NOW()
+    WHERE id = ANY($1::uuid[]) AND user_id = $2
+    RETURNING *
+  `,
+  DELETE_NOTIFICATIONS: `
+    DELETE FROM notifications
+    WHERE id = ANY($1::uuid[]) AND user_id = $2
+    RETURNING *
+  `,
+  GET_USER_PREFERENCES: `
+    SELECT notification_preferences FROM users
+    WHERE id = $1
+  `,
+  UPDATE_PREFERENCES: `
+    UPDATE users
+    SET notification_preferences = $2
+    WHERE id = $1
+    RETURNING notification_preferences
+  `
+};

--- a/src/queries/posts.queries.js
+++ b/src/queries/posts.queries.js
@@ -1,0 +1,35 @@
+module.exports = {
+  CREATE_POST: `
+    INSERT INTO posts (user_id, content, media_urls, visibility)
+    VALUES ($1, $2, $3, $4)
+    RETURNING *
+  `,
+  GET_POST: `
+    SELECT p.*,
+           (p.visibility = 'public' OR p.user_id = $2) AS can_view
+    FROM posts p
+    WHERE p.id = $1 AND p.deleted_at IS NULL
+  `,
+  GET_FEED_POSTS: `
+    SELECT p.*
+    FROM posts p
+    WHERE p.deleted_at IS NULL
+      AND (p.visibility = 'public' OR p.user_id = $1)
+    ORDER BY p.created_at DESC
+    LIMIT $2 OFFSET $3
+  `,
+  GET_USER_POSTS: `
+    SELECT p.*
+    FROM posts p
+    WHERE p.user_id = $1
+      AND (p.visibility = 'public' OR p.user_id = $2)
+      AND p.deleted_at IS NULL
+    ORDER BY p.created_at DESC
+    LIMIT $3 OFFSET $4
+  `,
+  DELETE_POST: `
+    DELETE FROM posts
+    WHERE id = $1 AND user_id = $2
+    RETURNING *
+  `
+};

--- a/src/queries/reels.queries.js
+++ b/src/queries/reels.queries.js
@@ -1,0 +1,37 @@
+module.exports = {
+  CREATE_REEL: `
+    INSERT INTO reels (user_id, media_url, thumbnail_url, duration, caption, music_track_url, music_track_name, music_artist_name)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    RETURNING *
+  `,
+  GET_REEL_BY_ID: `
+    SELECT r.*
+    FROM reels r
+    WHERE r.id = $1 AND r.deleted_at IS NULL
+  `,
+  GET_USER_FEED: `
+    SELECT r.*
+    FROM reels r
+    WHERE r.deleted_at IS NULL
+    ORDER BY r.created_at DESC
+    LIMIT $2 OFFSET $3
+  `,
+  GET_TRENDING_REELS: `
+    SELECT * FROM reels
+    WHERE deleted_at IS NULL
+    ORDER BY views_count DESC
+    LIMIT 20
+  `,
+  CREATE_REEL_COMMENT: `
+    INSERT INTO reel_comments (reel_id, user_id, content)
+    VALUES ($1, $2, $3)
+    RETURNING *
+  `,
+  RECORD_VIEW: `
+    INSERT INTO reel_views (reel_id, user_id, watch_duration)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (reel_id, user_id)
+      DO UPDATE SET watch_duration = EXCLUDED.watch_duration
+    RETURNING *
+  `
+};

--- a/src/queries/stories.queries.js
+++ b/src/queries/stories.queries.js
@@ -1,0 +1,40 @@
+module.exports = {
+  CREATE_STORY: `
+    INSERT INTO stories (user_id, media_url, media_type, caption, duration)
+    VALUES ($1, $2, $3, $4, $5)
+    RETURNING *
+  `,
+  GET_STORY: `
+    SELECT s.*
+    FROM stories s
+    WHERE s.id = $1 AND (s.user_id = $2 OR s.expires_at > NOW())
+  `,
+  GET_USER_STORIES: `
+    SELECT * FROM stories
+    WHERE user_id = $1 AND (user_id = $2 OR expires_at > NOW())
+    ORDER BY created_at DESC
+  `,
+  GET_FEED_STORIES: `
+    SELECT s.*
+    FROM stories s
+    JOIN follows f ON f.following_id = s.user_id
+    WHERE f.follower_id = $1 AND s.expires_at > NOW()
+    ORDER BY s.created_at DESC
+  `,
+  VIEW_STORY: `
+    INSERT INTO story_views (story_id, user_id, view_duration, completed, device_info, location_data)
+    VALUES ($1, $2, $3, $4, $5, $6)
+    RETURNING *
+  `,
+  DELETE_STORY: `
+    DELETE FROM stories
+    WHERE id = $1 AND user_id = $2
+    RETURNING *
+  `,
+  GET_STORY_STATS: `
+    SELECT COUNT(*) FILTER (WHERE completed) AS completed_views,
+           COUNT(*) AS total_views
+    FROM story_views
+    WHERE story_id = $1
+  `
+};

--- a/src/queries/users.queries.js
+++ b/src/queries/users.queries.js
@@ -1,0 +1,66 @@
+module.exports = {
+  CREATE_USER: `
+    INSERT INTO users (
+      email, mobile_number, username, password_hash,
+      first_name, last_name, avatar_url, bio, location, website, is_private
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+    RETURNING *
+  `,
+  GET_USER_BY_EMAIL: `
+    SELECT * FROM users
+    WHERE email = $1 AND deleted_at IS NULL
+  `,
+  GET_USER_BY_ID: `
+    SELECT * FROM users
+    WHERE id = $1 AND deleted_at IS NULL
+  `,
+  UPDATE_USER: `
+    UPDATE users
+    SET first_name = $2,
+        last_name = $3,
+        avatar_url = $4,
+        bio = $5,
+        location = $6,
+        website = $7,
+        is_private = $8,
+        updated_at = NOW()
+    WHERE id = $1
+    RETURNING *
+  `,
+  SEARCH_USERS: `
+    SELECT id, username, first_name, last_name, avatar_url
+    FROM users
+    WHERE (username ILIKE $1 OR full_name ILIKE $1)
+      AND deleted_at IS NULL
+    LIMIT $2 OFFSET $3
+  `,
+  DELETE_USER: `
+    DELETE FROM users
+    WHERE id = $1
+  `,
+  UPDATE_LAST_ACTIVE: `
+    UPDATE users
+    SET last_active_at = NOW()
+    WHERE id = $1
+  `,
+  CREATE_OTP: `
+    INSERT INTO verification_otps (user_id, otp, expires_at)
+    VALUES ($1, $2, NOW() + INTERVAL '10 minutes')
+  `,
+  GET_OTP: `
+    SELECT otp FROM verification_otps
+    WHERE user_id = $1 AND used_at IS NULL
+    ORDER BY created_at DESC
+    LIMIT 1
+  `,
+  USE_OTP: `
+    UPDATE verification_otps
+    SET used_at = NOW()
+    WHERE user_id = $1 AND otp = $2
+  `,
+  VERIFY_USER: `
+    UPDATE users
+    SET email_or_phone_verified = true
+    WHERE id = $1
+  `
+};


### PR DESCRIPTION
## Summary
- trim `.env.example` to only required environment variables and add missing ones
- add query modules for posts, messages, friends, reels, users, notifications, interests, affiliate and stories

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a70cc23b84832bbb327b247f4be317