### PR TITLE
feat: add user cover photo support

### DIFF
--- a/src/controllers/reactions.controller.js
+++ b/src/controllers/reactions.controller.js
@@ -139,7 +139,7 @@ class ReactionsController {
             // Get reactions with user info
             const result = await pool.query(
                 `SELECT cr.*, r.name as reaction_name, r.icon_url, 
-                        u.username, u.avatar_url
+                        u.username, u.avatar_url, u.cover_photo_url
                 FROM content_reactions cr
                 JOIN reactions r ON cr.reaction_id = r.id
                 JOIN users u ON cr.user_id = u.id

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -19,7 +19,7 @@ class UserController {
             const fullMobileNumber = countryCode ? `+${countryCode} ${mobileNumber}` : mobileNumber;
 
             // Create user
-            const result = await db.query(userQueries.CREATE_USER, [email, fullMobileNumber, username, passwordHash, firstName, lastName, profile.avatarUrl || null, profile.bio || null, profile.location || null, profile.website || null, profile.isPrivate || false]);
+            const result = await db.query(userQueries.CREATE_USER, [email, fullMobileNumber, username, passwordHash, firstName, lastName, profile.avatarUrl || null, profile.coverPhotoUrl || null, profile.bio || null, profile.location || null, profile.website || null, profile.isPrivate || false]);
 
             const user = result.rows[0];
 
@@ -106,7 +106,7 @@ class UserController {
     }
 
     async updateProfile(req, res) {
-        const { firstName, lastName, avatarUrl, bio, location, website, isPrivate } = req.body;
+        const { firstName, lastName, avatarUrl, coverPhotoUrl, bio, location, website, isPrivate } = req.body;
         
         try {
             const result = await db.query(userQueries.UPDATE_USER, [
@@ -114,6 +114,7 @@ class UserController {
                 firstName,
                 lastName,
                 avatarUrl,
+                coverPhotoUrl,
                 bio,
                 location,
                 website,

--- a/src/db/SCHEMA.md
+++ b/src/db/SCHEMA.md
@@ -8,7 +8,7 @@ This document outlines the business logic and data model for the social media pl
 ### User Management
 - **User Profiles**
   - Basic user information (email, username, mobile)
-  - Profile customization (avatar, bio, location, website)
+  - Profile customization (avatar, cover photo, bio, location, website)
   - Privacy settings (private/public accounts)
   - Account verification and moderation
   - Soft delete support for account recovery

--- a/src/db/create_tables.sql
+++ b/src/db/create_tables.sql
@@ -1044,6 +1044,7 @@ CASE
     ELSE (((first_name)::text || ' '::text) || (last_name)::text)
 END) STORED,
     avatar_url text,
+    cover_photo_url text,
     bio text,
     location character varying(100),
     website character varying(255),

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -121,6 +121,7 @@ CREATE TABLE IF NOT EXISTS users (
         END
     ) STORED,
     avatar_url text,
+    cover_photo_url text,
     bio text,
     location varchar(100),
     website varchar(255),

--- a/src/queries/interests.queries.js
+++ b/src/queries/interests.queries.js
@@ -17,7 +17,7 @@ module.exports = {
     LIMIT $2 OFFSET $3
   `,
   GET_SUGGESTED_USERS: `
-    SELECT u.id, u.username, u.avatar_url
+    SELECT u.id, u.username, u.avatar_url, u.cover_photo_url
     FROM users u
     WHERE u.id != $1 AND u.deleted_at IS NULL
     ORDER BY u.created_at DESC

--- a/src/queries/users.queries.js
+++ b/src/queries/users.queries.js
@@ -2,8 +2,8 @@ module.exports = {
   CREATE_USER: `
     INSERT INTO users (
       email, mobile_number, username, password_hash,
-      first_name, last_name, avatar_url, bio, location, website, is_private
-    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+      first_name, last_name, avatar_url, cover_photo_url, bio, location, website, is_private
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
     RETURNING *
   `,
   GET_USER_BY_EMAIL: `
@@ -19,16 +19,17 @@ module.exports = {
     SET first_name = $2,
         last_name = $3,
         avatar_url = $4,
-        bio = $5,
-        location = $6,
-        website = $7,
-        is_private = $8,
+        cover_photo_url = $5,
+        bio = $6,
+        location = $7,
+        website = $8,
+        is_private = $9,
         updated_at = NOW()
     WHERE id = $1
     RETURNING *
   `,
   SEARCH_USERS: `
-    SELECT id, username, first_name, last_name, avatar_url
+    SELECT id, username, first_name, last_name, avatar_url, cover_photo_url
     FROM users
     WHERE (username ILIKE $1 OR full_name ILIKE $1)
       AND deleted_at IS NULL

--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -14,6 +14,7 @@ class NotificationService extends BaseService {
             SELECT n.*, 
                    a.username as actor_username, 
                    a.avatar_url as actor_avatar_url
+                   a.cover_photo_url as actor_cover_photo_url
             FROM notifications n
             LEFT JOIN users a ON a.id = n.actor_id
             WHERE n.user_id = $1

--- a/src/services/post.service.js
+++ b/src/services/post.service.js
@@ -16,7 +16,7 @@ class PostService extends BaseService {
                 WHERE follower_id = $1 AND status = 'accepted'
             )
             SELECT p.*, 
-                   u.username, u.full_name, u.avatar_url, u.is_verified,
+                   u.username, u.full_name, u.avatar_url, u.cover_photo_url, u.is_verified,
                    (
                        SELECT COUNT(*) FROM content_reactions cr
                        WHERE cr.content_type = 'post' AND cr.content_id = p.id
@@ -49,7 +49,7 @@ class PostService extends BaseService {
 
         const query = `
             SELECT p.*, 
-                   u.username, u.full_name, u.avatar_url, u.is_verified,
+                   u.username, u.full_name, u.avatar_url, u.cover_photo_url, u.is_verified,
                    (
                        SELECT COUNT(*) FROM content_reactions cr
                        WHERE cr.content_type = 'post' AND cr.content_id = p.id

--- a/src/validations/user.validation.js
+++ b/src/validations/user.validation.js
@@ -35,6 +35,10 @@ const userValidation = {
             .optional()
             .isURL()
             .withMessage('Invalid avatar URL'),
+        body('coverPhotoUrl')
+            .optional()
+            .isURL()
+            .withMessage('Invalid cover photo URL'),
         body('bio')
             .optional()
             .isLength({ max: 500 })
@@ -78,6 +82,10 @@ const userValidation = {
             .optional()
             .isURL()
             .withMessage('Invalid avatar URL'),
+        body('coverPhotoUrl')
+            .optional()
+            .isURL()
+            .withMessage('Invalid cover photo URL'),
         body('bio')
             .optional()
             .isLength({ max: 500 })


### PR DESCRIPTION
## Summary
- add `cover_photo_url` to user schema
- handle cover photo in user queries, controllers, services, and validations
- document cover photo in schema docs

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68a72ca85378832baf4f91591b725709